### PR TITLE
feat: php opening tags (closes #12)

### DIFF
--- a/add_additional_mime_types_to_media_libary.php
+++ b/add_additional_mime_types_to_media_libary.php
@@ -1,3 +1,4 @@
+<?php
 function add_custom_mime_types($mimes){
     $new_file_types = array (
         'zip' => 'application/zip',

--- a/add_post_images_to_rss_feed.php
+++ b/add_post_images_to_rss_feed.php
@@ -1,3 +1,4 @@
+<?php
 function add_post_image_to_rss($content) {
     global $post;
     if ( has_post_thumbnail( $post->ID ) ){

--- a/define_excerpt_length.php
+++ b/define_excerpt_length.php
@@ -1,5 +1,6 @@
 // Add this to functions.php
 
+<?php
 function the_excerpt_max_charlength($charlength) {
     $excerpt = get_the_excerpt();
     $charlength++;
@@ -17,6 +18,7 @@ function the_excerpt_max_charlength($charlength) {
         echo $excerpt;
     }
 }
+?>
 
 // use the following snippet in any file to define the length of the excerpt for this file
 

--- a/disable_self_pingbacks.php
+++ b/disable_self_pingbacks.php
@@ -1,3 +1,4 @@
+<?php
 function disable_self_pingback( &$links ) {
     $home = get_option( 'home' );
     foreach ( $links as $l => $link )

--- a/exit-if-direct-access-to-file.php
+++ b/exit-if-direct-access-to-file.php
@@ -1,2 +1,3 @@
+<?php
 // Exit if direct access attempt to the file for example with a browser
 defined( 'ABSPATH' ) || exit;

--- a/fix-php-undefined-index.php
+++ b/fix-php-undefined-index.php
@@ -1,3 +1,4 @@
+<?php
 // Put this code in functions.php
 
 // Get array value

--- a/get-featured-image-from-rest-api.php
+++ b/get-featured-image-from-rest-api.php
@@ -1,3 +1,4 @@
+<?php
 // Put this code in functions.php or a separate plugin
 
 add_action('rest_api_init', 'register_rest_images' );

--- a/get-page-id-from-page-title.php
+++ b/get-page-id-from-page-title.php
@@ -1,3 +1,4 @@
+<?php
 // This will return an object of the page
 $page = get_page_by_title('page-name');
 $page_id = $page->ID;

--- a/get_all_tags_from_a_post.php
+++ b/get_all_tags_from_a_post.php
@@ -1,6 +1,7 @@
-  // Get an array of tag object from a post id
-  wp_get_post_tags(get_the_ID());
-  
-  // Get an array of tags name from a post id
-  wp_get_post_tags(get_the_ID(), array( 'fields' => 'names' )); // ids
+<?php
+// Get an array of tag object from a post id
+wp_get_post_tags(get_the_ID());
+
+// Get an array of tags name from a post id
+wp_get_post_tags(get_the_ID(), array( 'fields' => 'names' )); // ids
   

--- a/get_anything_with_page_id.php
+++ b/get_anything_with_page_id.php
@@ -1,4 +1,4 @@
-
+<?php
 // Get the page / post content (easy way)
 echo get_post_field('post_content', $page_id);
 

--- a/get_number_of_posts_in_term.php
+++ b/get_number_of_posts_in_term.php
@@ -1,3 +1,4 @@
+<?php
 //Show the number of posts in an archive page
 
 //get the term object

--- a/get_random_post_suggestion_by_categories.php
+++ b/get_random_post_suggestion_by_categories.php
@@ -1,3 +1,4 @@
+<?php
 //get categories of post
 $categories = get_the_terms( get_the_ID(), 'category' );
 

--- a/get_random_post_suggestion_by_tags.php
+++ b/get_random_post_suggestion_by_tags.php
@@ -1,3 +1,4 @@
+<?php
 //get tags of post
 $tags = get_the_terms( get_the_ID(), 'tag' );
 

--- a/remove_inline_styling_from_tag_cloud.php
+++ b/remove_inline_styling_from_tag_cloud.php
@@ -1,3 +1,4 @@
+<?php
 function remove_tagcloud_inline_styling($input){
     return preg_replace('/ style=("|\')(.*?)("|\')/','',$input);
 }


### PR DESCRIPTION
Hey! 👋 

In this PR i adressed issue #12.

I added PHP opening tags for every file but "embed_responsive_16_to_9_videos.php" because I don't know if the CSS should be commented out or not.

I also didn't add closing tags:
_"If a file contains only PHP code, it is preferable to omit the PHP closing tag at the end of the file. This prevents accidental whitespace or new lines being added after the PHP closing tag, which may cause unwanted effects because PHP will start output buffering when there is no intention from the programmer to send any output at that point in the script. "_
(source: https://www.php.net/manual/en/language.basic-syntax.phptags.php)

Would be great if you can accept this for hacktoberfest ;)

- Zentreax